### PR TITLE
Add argument to determine maximum memory allocation. Remove stdout printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .pytest_cache/
 tests/permutation_stats.txt
 tests/*.o
+**.so
+xswap.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ script:
   - python setup.py build
   - pip install .
   - pytest tests/
-  - g++ `pkg-config --cflags --libs python3` tests/test_bitset.cpp xswap/src/xswap.h \
-    xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
+  - >
+      g++ `pkg-config --cflags --libs python3` tests/test_bitset.cpp xswap/src/xswap.h
+      xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
   - ./tests/test_bitset.o
-  - g++ `pkg-config --cflags --libs python3` tests/test_roaring.cpp xswap/src/xswap.h \
-    xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
+  - >
+      g++ `pkg-config --cflags --libs python3` tests/test_roaring.cpp xswap/src/xswap.h
+      xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
   - ./tests/test_roaring.o
   - cat tests/permutation_stats.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - python setup.py build
   - pip install .
   - pytest tests/
+  - ls /usr/include/
   - g++ tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11 -I/usr/include/python3.6m
   - ./tests/test_bitset.o
   - g++ tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11 -I/usr/include/python3.6m

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
   - python setup.py build
   - pip install .
   - pytest tests/
-  - g++ tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
+  - g++ tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11 -I/usr/include/python3.6m
   - ./tests/test_bitset.o
-  - g++ tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
+  - g++ tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11 -I/usr/include/python3.6m
   - ./tests/test_roaring.o
   - cat tests/permutation_stats.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,18 @@ addons:
 compiler:
   - g++
 script:
+  - pkg-config --cflags --libs python3
   - python setup.py build
   - pip install .
   - pytest tests/
   - >
-      g++ `pkg-config --cflags --libs python3` tests/test_bitset.cpp xswap/src/xswap.h
-      xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
+      g++ tests/test_bitset.cpp xswap/src/xswap.h xswap/src/bitset.cpp
+      xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
+      `pkg-config --cflags --libs python3`
   - ./tests/test_bitset.o
   - >
-      g++ `pkg-config --cflags --libs python3` tests/test_roaring.cpp xswap/src/xswap.h
-      xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
+      g++ tests/test_roaring.cpp xswap/src/xswap.h xswap/src/bitset.cpp
+      xswap/lib/roaring.c -o tests/test_roaring.o -std=c++11
+      `pkg-config --cflags --libs python3`
   - ./tests/test_roaring.o
   - cat tests/permutation_stats.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 addons:
   apt:
     packages:
+      - pkg-config
       - python3-dev
 compiler:
   - g++
@@ -15,9 +16,8 @@ script:
   - python setup.py build
   - pip install .
   - pytest tests/
-  - ls /usr/include/
-  - g++ tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11 -I/usr/include/python3.6m
+  - g++ `pkg-config --cflags --libs python` tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
   - ./tests/test_bitset.o
-  - g++ tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11 -I/usr/include/python3.6m
+  - g++ `pkg-config --cflags --libs python` tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
   - ./tests/test_roaring.o
   - cat tests/permutation_stats.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7-dev"
 install:
+  - sudo apt-get install python3-dev
   - pip install -r tests-require.txt
 compiler:
   - g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: xenial
 language: python
 python:
   - 3.5
   - 3.6
-  - 3.7-dev
+  - 3.7
 install:
   - pip install -r tests-require.txt
 addons:
@@ -16,8 +17,8 @@ script:
   - python setup.py build
   - pip install .
   - pytest tests/
-  - g++ `pkg-config --cflags --libs python` tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
+  - g++ `pkg-config --cflags --libs python3` tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
   - ./tests/test_bitset.o
-  - g++ `pkg-config --cflags --libs python` tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
+  - g++ `pkg-config --cflags --libs python3` tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
   - ./tests/test_roaring.o
   - cat tests/permutation_stats.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ script:
   - python setup.py build
   - pip install .
   - pytest tests/
-  - g++ `pkg-config --cflags --libs python3` tests/test_bitset.cpp xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
+  - g++ `pkg-config --cflags --libs python3` tests/test_bitset.cpp xswap/src/xswap.h \
+    xswap/src/bitset.cpp xswap/lib/roaring.c -o tests/test_bitset.o -std=c++11
   - ./tests/test_bitset.o
-  - g++ `pkg-config --cflags --libs python3` tests/test_roaring.cpp xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
+  - g++ `pkg-config --cflags --libs python3` tests/test_roaring.cpp xswap/src/xswap.h \
+    xswap/lib/roaring.c xswap/src/bitset.cpp -o tests/test_roaring.o -std=c++11
   - ./tests/test_roaring.o
   - cat tests/permutation_stats.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 python:
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
+  - 3.5
+  - 3.6
+  - 3.7-dev
 install:
-  - sudo apt-get install python3-dev
   - pip install -r tests-require.txt
+addons:
+  apt:
+    packages:
+      - python3-dev
 compiler:
   - g++
 script:

--- a/tests/test_bitset.cpp
+++ b/tests/test_bitset.cpp
@@ -142,19 +142,20 @@ bool test_insert_existing(UncompressedBitSet edges_set) {
 }
 
 main(int argc, char const *argv[]) {
+    unsigned long long int max_malloc = 4000000;
     int num_tests = 7;
     bool test_passed[num_tests];
 
-    UncompressedBitSet edges_set = UncompressedBitSet(3, 3);
+    UncompressedBitSet edges_set = UncompressedBitSet(3, max_malloc);
     test_passed[0] = test_add(edges_set);
-    edges_set = UncompressedBitSet(3, 3);  // Reset so functions don't interfere
+    edges_set = UncompressedBitSet(3, max_malloc);  // Reset so functions don't interfere
     test_passed[1] = test_remove(edges_set);
     test_passed[2] = test_oob_insert(edges_set);
     test_passed[3] = test_oob_access(edges_set);
     test_passed[4] = test_oob_remove(edges_set);
-    edges_set = UncompressedBitSet(3, 3);
+    edges_set = UncompressedBitSet(3, max_malloc);
     test_passed[5] = test_remove_nonexistent(edges_set);
-    edges_set = UncompressedBitSet(3, 3);
+    edges_set = UncompressedBitSet(3, max_malloc);
     test_passed[6] = test_insert_existing(edges_set);
 
     bool all_tests_passed = true;

--- a/xswap/src/xswap.cpp
+++ b/xswap/src/xswap.cpp
@@ -1,9 +1,10 @@
 #include <random>
 #include "xswap.h"
 
-void swap_edges(Edges edges, int num_swaps, Conditions cond, statsCounter *stats) {
+void swap_edges(Edges edges, int num_swaps, Conditions cond, statsCounter *stats,
+                unsigned long long int max_malloc) {
     // Initialize bitset for possible edges
-    BitSet edges_set = BitSet(edges);
+    BitSet edges_set = BitSet(edges, max_malloc);
 
     // Initialize unbiased random number generator
     std::mt19937 rng(cond.seed);

--- a/xswap/src/xswap.h
+++ b/xswap/src/xswap.h
@@ -1,13 +1,12 @@
+#include <Python.h>
 #include "../lib/roaring.hh"
 
 extern int CHAR_BITS;
-extern unsigned long long int MAX_MALLOC;
 
 struct Edges {
     int** edge_array;
     int num_edges;
-    int max_source;
-    int max_target;
+    int max_id;
 };
 
 // Slower bitset
@@ -29,8 +28,8 @@ class UncompressedBitSet
 {
     public:
         UncompressedBitSet() = default;
-        UncompressedBitSet(int max_source, int max_target);
-        UncompressedBitSet(Edges edges);
+        UncompressedBitSet(int max_id, unsigned long long int max_malloc);
+        UncompressedBitSet(Edges edges, unsigned long long int max_malloc);
         bool contains(int *edge);
         void add(int *edge);
         void remove(int *edge);
@@ -39,7 +38,7 @@ class UncompressedBitSet
     private:
         char* bitset;
         size_t max_cantor;
-        void create_bitset(size_t num_elements);
+        void create_bitset(size_t num_elements, unsigned long long int max_malloc);
         char get_bit(char word, char bit_position);
         void set_bit_true(char* word, char bit_position);
         void set_bit_false(char* word, char bit_position);
@@ -49,11 +48,12 @@ class UncompressedBitSet
 class BitSet
 {
     public:
-        BitSet(Edges edges);
+        BitSet(Edges edges, unsigned long long int max_malloc);
         bool contains(int *edge);
         void add(int *edge);
         void remove(int *edge);
         void free_array();
+        PyObject* runtime_warning_roaring(void);
         UncompressedBitSet uncompressed_set;
 
     private:
@@ -79,7 +79,8 @@ struct Conditions {
 
 size_t cantor_pair(int* edge);
 
-void swap_edges(Edges edges, int num_swaps, Conditions cond, statsCounter *stats);
+void swap_edges(Edges edges, int num_swaps, Conditions cond, statsCounter *stats,
+                unsigned long long int max_malloc);
 
 bool is_valid_edge(int *edge, BitSet edges_set, Conditions cond,
                    statsCounter *stats);

--- a/xswap/src/xswap_wrapper.cpp
+++ b/xswap/src/xswap_wrapper.cpp
@@ -87,7 +87,7 @@ static PyObject* wrap_xswap(PyObject *self, PyObject *args) {
     stats.num_swaps = num_swaps;
 
     // Perform XSwap
-    swap_edges(edges, num_swaps, valid_cond, &stats, (unsigned long long int)max_malloc);
+    swap_edges(edges, num_swaps, valid_cond, &stats, max_malloc);
 
     // Get new edges as python list
     PyObject* py_list = edges_to_py_list(edges);

--- a/xswap/src/xswap_wrapper.cpp
+++ b/xswap/src/xswap_wrapper.cpp
@@ -1,4 +1,3 @@
-#include <Python.h>
 #include "xswap.h"
 
 #define XSWAP_MODULE
@@ -63,17 +62,17 @@ static PyObject* stats_to_py_dict(statsCounter& stats) {
 static PyObject* wrap_xswap(PyObject *self, PyObject *args) {
     // Get arguments from python and compute quantities where needed
     PyObject *py_edges, *py_excluded_edges;
-    int max_source, max_target, num_swaps, seed, allow_self_loop, allow_antiparallel;
-    int parsed_successfully = PyArg_ParseTuple(args, "OOiippii", &py_edges,
-        &py_excluded_edges, &max_source, &max_target, &allow_self_loop,
-        &allow_antiparallel, &num_swaps, &seed);
+    int max_id, num_swaps, seed, allow_self_loop, allow_antiparallel;
+    unsigned long long int max_malloc;
+    int parsed_successfully = PyArg_ParseTuple(args, "OOippiiK", &py_edges,
+        &py_excluded_edges, &max_id, &allow_self_loop,
+        &allow_antiparallel, &num_swaps, &seed, &max_malloc);
     if (!parsed_successfully)
         return NULL;
 
     // Load edges from python list
     Edges edges = py_list_to_edges(py_edges);
-    edges.max_source = max_source;
-    edges.max_target = max_target;
+    edges.max_id = max_id;
     Edges excluded_edges = py_list_to_edges(py_excluded_edges);
 
     // Set the conditions under which new edges are accepted
@@ -88,7 +87,7 @@ static PyObject* wrap_xswap(PyObject *self, PyObject *args) {
     stats.num_swaps = num_swaps;
 
     // Perform XSwap
-    swap_edges(edges, num_swaps, valid_cond, &stats);
+    swap_edges(edges, num_swaps, valid_cond, &stats, (unsigned long long int)max_malloc);
 
     // Get new edges as python list
     PyObject* py_list = edges_to_py_list(edges);

--- a/xswap/xswap.py
+++ b/xswap/xswap.py
@@ -6,7 +6,7 @@ import xswap._xswap_backend
 def permute_edge_list(edge_list: List[Tuple[int, int]], allow_self_loops: bool = False,
                       allow_antiparallel: bool = False, multiplier: float = 10,
                       excluded_edges: Set[Tuple[int, int]] = set(), seed: int = 0,
-                      max_malloc: int = 400000000):
+                      max_malloc: int = 4000000000):
     """
     Permute the edges of a graph using the XSwap method given by Hanhijärvi,
     et al. (doi.org/f3mn58). XSwap is a degree-preserving network randomization

--- a/xswap/xswap.py
+++ b/xswap/xswap.py
@@ -6,7 +6,7 @@ import xswap._xswap_backend
 def permute_edge_list(edge_list: List[Tuple[int, int]], allow_self_loops: bool = False,
                       allow_antiparallel: bool = False, multiplier: float = 10,
                       excluded_edges: Set[Tuple[int, int]] = set(), seed: int = 0,
-                      max_malloc: int = 4_000_000_000):
+                      max_malloc: int = 400000_000):
     """
     Permute the edges of a graph using the XSwap method given by Hanhijärvi,
     et al. (doi.org/f3mn58). XSwap is a degree-preserving network randomization

--- a/xswap/xswap.py
+++ b/xswap/xswap.py
@@ -6,7 +6,7 @@ import xswap._xswap_backend
 def permute_edge_list(edge_list: List[Tuple[int, int]], allow_self_loops: bool = False,
                       allow_antiparallel: bool = False, multiplier: float = 10,
                       excluded_edges: Set[Tuple[int, int]] = set(), seed: int = 0,
-                      max_malloc: int = 400000_000):
+                      max_malloc: int = 400000000):
     """
     Permute the edges of a graph using the XSwap method given by Hanhijärvi,
     et al. (doi.org/f3mn58). XSwap is a degree-preserving network randomization

--- a/xswap/xswap.py
+++ b/xswap/xswap.py
@@ -5,7 +5,8 @@ import xswap._xswap_backend
 
 def permute_edge_list(edge_list: List[Tuple[int, int]], allow_self_loops: bool = False,
                       allow_antiparallel: bool = False, multiplier: float = 10,
-                      excluded_edges: Set[Tuple[int, int]] = set(), seed: int = 0):
+                      excluded_edges: Set[Tuple[int, int]] = set(), seed: int = 0,
+                      max_malloc: int = 4_000_000_000):
     """
     Permute the edges of a graph using the XSwap method given by Hanhijärvi,
     et al. (doi.org/f3mn58). XSwap is a degree-preserving network randomization
@@ -39,18 +40,38 @@ def permute_edge_list(edge_list: List[Tuple[int, int]], allow_self_loops: bool =
     seed : int
         Random seed that will be passed to the C++ Mersenne Twister 19937 random
         number generator.
+    max_malloc : int (`unsigned long long int` in C)
+        The maximum amount of memory to be allocated using `malloc` when making
+        a bitset to hold edges. An uncompressed bitset is implemented for
+        holding edges that is significantly faster than alternatives. However,
+        it is memory-inefficient and will not be used if more memory is required
+        than `max_malloc`. Above the threshold, a Roaring bitset will be used.
+
+    Returns
+    -------
+    new_edges : List[Tuple[int, int]]
+        Edge list of a permutation of the network given as `edge_list`
+    stats : Dict[str, int]
+        Information about the permutation performed. Gives the following information:
+        `swap_attempts` - number of attempted swaps
+        `same_edge` - number of swaps rejected because one edge was chosen twice
+        `self_loop` - number of swaps rejected because new edge is a self-loop
+        'duplicate` - number of swaps rejected because new edge already exists
+        `undir_duplicate` - number of swaps rejected because the network is
+            undirected and the reverse of the new edge already exists
+        `excluded` - number of swaps rejected because new edge was among excluded
     """
-    max_source = max([i[0] for i in edge_list])
-    max_target = max([i[1] for i in edge_list])
-    max_source, max_target = sorted([max_source, max_target])
-
-    num_swaps = int(multiplier * len(edge_list))
-
     if len(edge_list) != len(set(edge_list)):
         raise ValueError("Edge list contained duplicate edges.")
 
+    # Number of attempted XSwap swaps
+    num_swaps = int(multiplier * len(edge_list))
+
+    # Compute the maximum node ID (for creating the bitset)
+    max_id = max(map(max, edge_list))
+
     new_edges, stats = xswap._xswap_backend._xswap(
-        edge_list, list(excluded_edges), max_source, max_target, allow_self_loops,
-        allow_antiparallel, num_swaps, seed)
+        edge_list, list(excluded_edges), max_id, allow_self_loops,
+        allow_antiparallel, num_swaps, seed, max_malloc)
 
     return new_edges, stats


### PR DESCRIPTION
* Replace stdout logging with Python warnings
* Replace `max_source`, `max_target` with single `max_id`
* Add `max_malloc` argument to allow overriding `malloc` maxima
